### PR TITLE
connectivity-exporter: monitoring all interfaces

### DIFF
--- a/connectivity-exporter/packet/bpf.go
+++ b/connectivity-exporter/packet/bpf.go
@@ -156,11 +156,15 @@ type ebpfAttachment struct {
 
 // attachProgramToNetworkInterface returns an ebpfAttachment object
 func attachProgramToNetworkInterface(prog *ebpf.Program, networkInterface string) (*ebpfAttachment, error) {
-	iface, err := net.InterfaceByName(networkInterface)
-	if err != nil {
-		return nil, err
+	ifaceIndex := 0
+	if networkInterface != "" {
+		iface, err := net.InterfaceByName(networkInterface)
+		if err != nil {
+			return nil, err
+		}
+		ifaceIndex = iface.Index
 	}
-	fd, err := openRawSock(iface.Index)
+	fd, err := openRawSock(ifaceIndex)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The network interface name could be specified with the "-i" CLI flag but
it was not possible to monitor all network interfaces.

With this patch, connectivity-exporter will monitor all network
interfaces when the "-i" flag is empty or missing.

It works by setting sll_ifindex to zero: see "man 7 packet":

> sll_ifindex  is the interface index of the interface (see
> netdevice(7)); 0 matches any interface (only permitted for binding).

