### PR TITLE
connectivity-exporter: add CLI flag -metrics-addr

### DIFF
--- a/connectivity-exporter/main.go
+++ b/connectivity-exporter/main.go
@@ -27,6 +27,7 @@ var (
 	networkInterface = flag.String("i", "", "Network interface to listen on")
 	cidrs            = flag.String("r", "", "Network CIDRs, comma separated")
 	ports            = flag.String("p", "", "Ports, comma separated")
+	addr             = flag.String("metrics-addr", ":19100", "Bind and listen address for the metrics")
 
 	incs      = make(chan *metrics.Inc)
 	snapshots = make(chan promextra.Snapshot)
@@ -64,7 +65,7 @@ func main() {
 	go dataSource.TrackExecutionTime(ctx, wg, time.NewTicker(time.Second).C, snapshots)
 	go dataSource.TrackConnections(ctx, wg, time.NewTicker(time.Second).C, incs)
 	go metrics.Apply(ctx, wg, incs, snapshots)
-	go metrics.ListenAndServe(ctx, wg)
+	go metrics.ListenAndServe(ctx, *addr, wg)
 
 	sig := <-signals
 	klog.Infof("Received signal '%s'. Initiating a graceful shutdown.\n", sig)

--- a/connectivity-exporter/metrics/metrics.go
+++ b/connectivity-exporter/metrics/metrics.go
@@ -16,13 +16,13 @@ import (
 )
 
 // ListenAndServe starts the http server to expose the prometheus metrics
-func ListenAndServe(ctx context.Context, wg *sync.WaitGroup) {
+func ListenAndServe(ctx context.Context, addr string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	defer klog.Infoln("Bye.")
 
 	http.Handle("/metrics", promhttp.Handler())
 	klog.Info("Starting connectivity-exporter")
-	server := &http.Server{Addr: ":19100", Handler: nil}
+	server := &http.Server{Addr: addr, Handler: nil}
 
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
connectivity-exporter was previously listening on port 19100 on all
network interfaces and this was not configurable.

This patch adds a CLI flag -metrics-addr to make this configurable. The
default is still ":19100" to keep the previous behaviour unchanged.

This is useful when the Kubernetes cluster already has something
listening on port 19100.
