### PR TITLE
build: container images and helm charts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
     - name: Build
       uses: docker/build-push-action@v2
       with:
-        context: connectivity-exporter/base-image
-        file: connectivity-exporter/base-image/Dockerfile
+        context: connectivity-exporter
+        file: connectivity-exporter/Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/charts/connectivity-monitor/Chart.yaml
+++ b/charts/connectivity-monitor/Chart.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: connectivity-monitor
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/charts/connectivity-monitor/templates/ds.yaml
+++ b/charts/connectivity-monitor/templates/ds.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectivity-exporter-config
+  namespace: {{ .Release.Namespace }}
+  labels: {app: connectivity-exporter}
+data:
+  filtered-ports: "443,6443"
+  filtered-ips: "0.0.0.0/0"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: connectivity-exporter
+  namespace: {{ .Release.Namespace }}
+  labels: {app: connectivity-exporter}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+
+  selector: {matchLabels: {app: connectivity-exporter}}
+  template:
+    metadata: {labels: {app: connectivity-exporter}}
+    spec:
+      serviceAccountName: connectivity-monitor
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+
+      containers:
+
+      - name: connectivity-exporter
+        image: {{ .Values.image.registry}}/{{ .Values.image.name }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          /bin/connectivity-exporter -r $FILTERED_IPS -p $FILTERED_PORTS -v 0 -metrics-addr "{{ .Values.metrics.host }}:{{ .Values.metrics.port }}"
+          echo "Good bye!"
+        env:
+          - name: FILTERED_PORTS
+            valueFrom:
+              configMapKeyRef:
+                name: connectivity-exporter-config
+                key: filtered-ports
+          - name: FILTERED_IPS
+            valueFrom:
+              configMapKeyRef:
+                name: connectivity-exporter-config
+                key: filtered-ips
+
+        securityContext: {capabilities: {add: [NET_ADMIN, SYS_RESOURCE, SYS_ADMIN]}}
+        resources:
+          requests: {cpu: 200m, memory: 750Mi}
+          limits:   {cpu: 2, memory: 3Gi}
+        ports: [{containerPort: {{ .Values.metrics.port }}}]
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.metrics.port }}

--- a/charts/connectivity-monitor/templates/rbac.yaml
+++ b/charts/connectivity-monitor/templates/rbac.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectivity-monitor
+  namespace: {{ .Release.Namespace }}
+  labels: {app: connectivity-monitor}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: connectivity-monitor
+  labels: {app: connectivity-monitor}
+rules:
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: connectivity-monitor
+  labels: {app: connectivity-monitor}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: connectivity-monitor
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: connectivity-monitor

--- a/charts/connectivity-monitor/values.yaml
+++ b/charts/connectivity-monitor/values.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for connectivity-monitor.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  registry: ghcr.io
+  name: gardener/connectivity-monitor
+  tag: test
+  pullPolicy: Always
+
+metrics:
+  host: ""
+  port: "19101"

--- a/connectivity-exporter/Dockerfile
+++ b/connectivity-exporter/Dockerfile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang:1.16-alpine3.13 as builder
+RUN apk add tmux curl tcpdump sed less gcc libc-dev libpcap-dev bind-tools util-linux make clang linux-headers libbpf-dev
+
+# Cache go modules so they won't be downloaded at each build
+COPY go.mod go.sum base-image/main.go /dependencies/
+RUN cd /dependencies && go mod download all && go build . && rm -f m
+
+COPY ./ /build
+RUN cd /build && make
+
+FROM golang:1.16-alpine3.13
+COPY --from=builder /build/bin/connectivity-exporter /bin/connectivity-exporter
+
+CMD printf 'Example of command:\ndocker run --privileged --net=host -ti --rm ghcr.io/gardener/connectivity-monitor:test /bin/connectivity-exporter -r 0.0.0.0/0 -p 443,6443 -i wlp4s0\n'

--- a/connectivity-exporter/Makefile
+++ b/connectivity-exporter/Makefile
@@ -2,7 +2,48 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+REGISTRY ?= ghcr.io
+IMAGE_NAME ?= gardener/connectivity-monitor
+IMAGE_TAG ?= main
+
 all: build
+
+.PHONY: docker/build
+docker/build:
+	docker build -t $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile .
+
+.PHONY: docker/push
+docker/push:
+	docker push $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+.PHONY: helm/generate
+helm/generate:
+	helm template \
+		connectivity-monitor ../charts/connectivity-monitor \
+		--output-dir bin/ \
+		--create-namespace \
+		--namespace connectivity-monitor \
+		--values ../charts/connectivity-monitor/values.yaml \
+		--set-string image.registry=$(REGISTRY) \
+		--set-string image.name=$(IMAGE_NAME) \
+		--set-string image.tag=$(IMAGE_TAG)
+
+.PHONY: helm/install
+helm/install:
+	helm upgrade --install \
+		connectivity-monitor ../charts/connectivity-monitor \
+		--create-namespace \
+		--namespace connectivity-monitor \
+		--values ../charts/connectivity-monitor/values.yaml \
+		--set-string image.registry=$(REGISTRY) \
+		--set-string image.name=$(IMAGE_NAME) \
+		--set-string image.tag=$(IMAGE_TAG)
+
+.PHONY: helm/uninstall
+helm/uninstall:
+	helm uninstall \
+		connectivity-monitor \
+		--namespace connectivity-monitor
 
 CLANG_OS_FLAGS = ""
 


### PR DESCRIPTION
This adds Makefile targets:
- docker/build
- docker/push
- helm/generate
- helm/install
- helm/uninstall

The following environment variables can be redefined before running 'make':
- REGISTRY
- IMAGE_NAME
- IMAGE_TAG

For example, I run
```
export REGISTRY=xxxxx.azurecr.io
export IMAGE_NAME=connectivity-monitor
export IMAGE_TAG=albantest
```

With this, I can test:
```
$ time make docker/build docker/push helm/install
```
And then, the pod is deployed:
```
$ kubectl logs -n connectivity-monitor connectivity-exporter-65rz4
2021/11/08 14:45:01 maxprocs: Updating GOMAXPROCS=2: determined from CPU quota
I1108 14:45:02.076150       9 metrics.go:24] Starting connectivity-exporter
I1108 14:45:24.076205       9 packet.go:245] sni: dc.services.visualstudio.com, connections: 1
...
```

There are some errors but that could be debugged later:
- `packet.go:159] Empty SNI`
- `sni: , connections: 2`

---

TODO:
- [ ] Add missing helm charts
- [ ] 