### PR TITLE
Fix Prometheus counters for each SNI

### DIFF
--- a/connectivity-exporter/packet/bpf.go
+++ b/connectivity-exporter/packet/bpf.go
@@ -424,8 +424,8 @@ func getStats(outerMap *ebpf.Map) (out []map[string][2]uint64, err error) {
 		for innerEntries.Next(&innerKey, &innerValue) {
 			sniString := strings.SplitN(innerKey, "\000", 2)[0]
 
-			// succeeded_seconds := innerValue[0]
-			// failed_seconds := innerValue[1]
+			// succeeded_connections := innerValue[0]
+			// failed_connections := innerValue[1]
 			out[outerKey][sniString] = innerValue
 		}
 		if err := innerEntries.Err(); err != nil {

--- a/connectivity-exporter/packet/c/cap.c
+++ b/connectivity-exporter/packet/c/cap.c
@@ -103,8 +103,8 @@ static inline void run_test_hook(__u64 i)
     char sni_string[TLS_MAX_SERVER_NAME_LEN] = "my-sni-server";
     s = bpf_map_lookup_elem(inner_map, sni_string);
     if (s) {
-      s->failed_seconds++;
-      s->succeeded_seconds++;
+      s->failed_connections++;
+      s->succeeded_connections++;
     } else {
       struct sni_stats_t new_stats = {42, 43};
       bpf_map_update_elem(inner_map, sni_string, &new_stats, BPF_ANY);
@@ -128,9 +128,9 @@ static inline void add_connection_to_stats(struct tuple_key_t *key, char *sni_st
   s = bpf_map_lookup_elem(inner_map, sni_string);
   if (s) {
     if (successful_connection)
-      __sync_fetch_and_add(&s->succeeded_seconds, 1); // TODO: Use core specific datastructures to avoid synchronization
+      __sync_fetch_and_add(&s->succeeded_connections, 1); // TODO: Use core specific datastructures to avoid synchronization
     else
-      __sync_fetch_and_add(&s->failed_seconds, 1);
+      __sync_fetch_and_add(&s->failed_connections, 1);
   } else {
     struct sni_stats_t new_stats = {
       successful_connection ? 1 : 0,

--- a/connectivity-exporter/packet/c/types.h
+++ b/connectivity-exporter/packet/c/types.h
@@ -105,8 +105,8 @@ struct tuple_data_t {
 };
 
 struct sni_stats_t {
-    __u64 succeeded_seconds; // TODO: Should be succeeded_connections instead of seconds
-    __u64 failed_seconds;    // TODO: Should be failed_connections instead of seconds
+    __u64 succeeded_connections;
+    __u64 failed_connections;
 };
 
 // A number of linear buckets in histogram.

--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -172,22 +172,22 @@ seconds.
 
 ```
 struct sni_stats_t {
-    u64 succeeded_seconds
-    u64 failed_seconds
+    u64 succeeded_connections
+    u64 failed_connections
 }
 ```
 
 When the eBPF program parses an RST packet for an existing connection with a
-known SNI, the program needs to increment the `failed_seconds` counter at the
+known SNI, the program needs to increment the `failed_connections` counter at the
 correct index.
 We have two implementation choices:.
 
-* Increment the `failed_seconds` counter at the "now" index, as specified in
+* Increment the `failed_connections` counter at the "now" index, as specified in
   the `ticker_clock` map.
   In this case, there is a 20-second delay before the event is recorded in the
   Prometheus graphs but the event is synchronized with the events about
   successful connections.
-* Increment the `failed_seconds` counter at the index
+* Increment the `failed_connections` counter at the index
   `ticker_clock_first_packet` as specified in the "connections" map for that
   connection.
   In that case, the event is reported sooner, but the "failed" graph isn't
@@ -196,7 +196,7 @@ We have two implementation choices:.
   (older than 20 seconds) don't corrupt data.
 
 When the eBPF program parses a FIN packet for an existing connection with known
-SNI, it increments the `succeeded_seconds` counter.
+SNI, it increments the `succeeded_connections` counter.
 
 ## Flow: the scrapper Goroutine
 
@@ -209,7 +209,7 @@ In an infinite loop:
   * If the connection was in `SYN_RECEIVED` or `SYNACK_RECEIVED` state,
     increment the dormant connection counter.
   * If the connection was in `SNI_RECEIVED` state, increment the local
-    `succeeded_seconds` counter for that SNI.
+    `succeeded_connections` counter for that SNI.
 
 * Iterate on the "stats" map:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Rename `{succeeded,failed}_seconds` to `{succeeded,failed}_connections` in the BPF map sni_stats
* Separate stats for each SNI
* On inactive seconds, carry over failed second state

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
