### PR TITLE
Expire metrics of inactive SNIs after 5 minutes

### DIFF
--- a/connectivity-exporter/Makefile
+++ b/connectivity-exporter/Makefile
@@ -115,9 +115,9 @@ check-clean-work-tree:
 test: bpf
 ifneq ($(shell id -u),0)
 	$(warning ***Root privileges are required for executing BPF-related tests***)
-	sudo $(shell which go) test -tags testing -v ./... -count=1
+	sudo $(shell which go) test -tags testing -timeout 30s -v ./... -count=1
 else
-	go test -tags testing -v ./... -count=1
+	go test -tags testing -timeout 30s -v ./... -count=1
 endif
 
 .PHONY: benchmark

--- a/connectivity-exporter/metrics/metrics_test.go
+++ b/connectivity-exporter/metrics/metrics_test.go
@@ -1,0 +1,171 @@
+package metrics
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSNI(t *testing.T) {
+	defer resetMetrics()
+	sni := "test.sni"
+	inc := &Inc{
+		AllSeconds:                  1,
+		ActiveSeconds:               1,
+		FailedSeconds:               1,
+		ActiveFailedSeconds:         1,
+		SuccessfulConnections:       2,
+		UnacknowledgedConnections:   0,
+		RejectedConnections:         5,
+		RejectedConnectionsByClient: 1,
+		OrphanPackets:               1,
+		SNI:                         NewSNI(sni),
+	}
+	inc.SNI.StartTTL(&RealTimer{
+		Timer: time.NewTimer(TTL),
+	})
+	applyInc(inc)
+
+	const secondsMetadata = `
+		# HELP connectivity_exporter_seconds_total Total number of seconds.
+		# TYPE connectivity_exporter_seconds_total counter
+	`
+
+	secondsExpected := `
+		connectivity_exporter_seconds_total{kind="active",sni="test.sni"} 1
+		connectivity_exporter_seconds_total{kind="active_failed",sni="test.sni"} 1
+		connectivity_exporter_seconds_total{kind="clock",sni="test.sni"} 1
+		connectivity_exporter_seconds_total{kind="failed",sni="test.sni"} 1
+	`
+
+	if err := testutil.CollectAndCompare(seconds, strings.NewReader(secondsMetadata+secondsExpected)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+	const connectionsMetadata = `
+		# HELP connectivity_exporter_connections_total Total number of new connections.
+		# TYPE connectivity_exporter_connections_total counter
+	`
+
+	connectionsExpected := `
+		connectivity_exporter_connections_total{kind="rejected",sni="test.sni"} 5
+		connectivity_exporter_connections_total{kind="rejected_by_client",sni="test.sni"} 1
+		connectivity_exporter_connections_total{kind="successful",sni="test.sni"} 2
+		connectivity_exporter_connections_total{kind="unacknowledged",sni="test.sni"} 0
+	`
+
+	if err := testutil.CollectAndCompare(connections, strings.NewReader(connectionsMetadata+connectionsExpected)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+
+	const packetsMetadata = `
+		# HELP connectivity_exporter_packets_total Total number of new packets.
+		# TYPE connectivity_exporter_packets_total counter
+	`
+
+	packetsExpected := `
+		connectivity_exporter_packets_total{kind="orphan",sni="test.sni"} 1
+	`
+
+	if err := testutil.CollectAndCompare(packets, strings.NewReader(packetsMetadata+packetsExpected)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+type mockTimer struct {
+	c     chan time.Time
+	reset bool
+	wg    *sync.WaitGroup
+}
+
+func (t *mockTimer) resetTimer() {
+	t.reset = true
+}
+
+func (t *mockTimer) getChannel() <-chan time.Time {
+	return t.c
+}
+
+func (t *mockTimer) cleanup() {
+	t.wg.Done()
+}
+
+func TestTTL(t *testing.T) {
+	defer resetMetrics()
+	sni := "testsni"
+	inc := &Inc{
+		AllSeconds:                  1,
+		ActiveSeconds:               1,
+		FailedSeconds:               1,
+		ActiveFailedSeconds:         1,
+		SuccessfulConnections:       2,
+		UnacknowledgedConnections:   0,
+		RejectedConnections:         5,
+		RejectedConnectionsByClient: 1,
+		OrphanPackets:               1,
+		SNI:                         NewSNI(sni),
+	}
+
+	ch := make(chan time.Time)
+	wg := &sync.WaitGroup{}
+
+	go inc.SNI.StartTTL(&mockTimer{
+		c:  ch,
+		wg: wg,
+	})
+
+	wg.Add(1)
+
+	// Apply the increment and verify that the metrics got created
+	applyInc(inc)
+	if testutil.CollectAndCount(seconds) != 4 {
+		t.Errorf("Expected 4 metrics got: %d", testutil.CollectAndCount(seconds))
+	}
+
+	// expire metrics
+	ch <- time.Now()
+	wg.Wait()
+
+	// verify metrics are gone
+	if testutil.CollectAndCount(seconds) != 0 {
+		t.Errorf("Expected 0 metrics got: %d", testutil.CollectAndCount(seconds))
+	}
+
+	// SNI appears again after it has been expired
+	inc = &Inc{
+		AllSeconds:                  1,
+		ActiveSeconds:               1,
+		FailedSeconds:               1,
+		ActiveFailedSeconds:         1,
+		SuccessfulConnections:       2,
+		UnacknowledgedConnections:   0,
+		RejectedConnections:         5,
+		RejectedConnectionsByClient: 1,
+		OrphanPackets:               1,
+		SNI:                         NewSNI(sni),
+	}
+	inc.SNI.StartTTL(&mockTimer{
+		c:  ch,
+		wg: wg,
+	})
+
+	applyInc(inc)
+	if testutil.CollectAndCount(seconds) != 4 {
+		t.Errorf("Expected 4 metrics got: %d", testutil.CollectAndCount(seconds))
+	}
+
+	// RefreshTTL should not affect the metrics
+	inc.SNI.refreshTTL <- nil
+	if testutil.CollectAndCount(seconds) != 4 {
+		t.Errorf("Expected 4 metrics got: %d", testutil.CollectAndCount(seconds))
+	}
+}
+
+func resetMetrics() {
+	seconds.Reset()
+	connections.Reset()
+	packets.Reset()
+}

--- a/connectivity-exporter/metrics/types.go
+++ b/connectivity-exporter/metrics/types.go
@@ -5,6 +5,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -22,11 +24,18 @@ type Inc struct {
 	RejectedConnections,
 	RejectedConnectionsByClient,
 	OrphanPackets float64
-	SNI string
+	SNI *SNI
+}
+
+type SNI struct {
+	refreshTTL chan interface{}
+	name       string
+	Expired    bool
 }
 
 const (
-	namespace = "connectivity_exporter"
+	TTL       time.Duration = time.Minute * 5
+	namespace               = "connectivity_exporter"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, if an SNI is detected it is exposed indefinitely, or until the
exporter is restarted. With this change, each SNI receives a TTL that will
expire after 5 minutes of inactivity. A new connection will refresh the
TTL.

* Add test case for applying increments
* Add test case for expiring TTL
* Add a timeout of 30s to the Makefile `test` command

