### PR TITLE
Fix an issue where the metrics did not get reapplied

### DIFF
--- a/connectivity-exporter/metrics/types.go
+++ b/connectivity-exporter/metrics/types.go
@@ -5,6 +5,7 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,6 +40,8 @@ const (
 )
 
 var (
+	SNIMutex = sync.Mutex{}
+
 	seconds = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,

--- a/connectivity-exporter/packet/packet.go
+++ b/connectivity-exporter/packet/packet.go
@@ -233,6 +233,8 @@ func (s *NetworkDataSource) TrackConnections(ctx context.Context, wg *sync.WaitG
 }
 
 func (s *State) deleteExpiredSNIs() {
+	metrics.SNIMutex.Lock()
+	defer metrics.SNIMutex.Unlock()
 	for name, sni := range s.snis {
 		if sni.Expired {
 			delete(s.snis, name)


### PR DESCRIPTION
**What this PR does / why we need it**:

* The refreshTTL channel does not have a reader if the TTL expires at the
same time that it would be refreshed. This deadlocks the metrics apply
goroutine as well as the packet goroutine.

* Add a mutex for the SNI map which is used for expiring the SNI metrics in
different goroutines.
