### PR TITLE
Increase the TTL to 15 minutes

### DIFF
--- a/connectivity-exporter/metrics/types.go
+++ b/connectivity-exporter/metrics/types.go
@@ -35,7 +35,7 @@ type SNI struct {
 }
 
 const (
-	TTL       time.Duration = time.Minute * 5
+	TTL       time.Duration = time.Minute * 15
 	namespace               = "connectivity_exporter"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The counters of snis were reset even though the cluster was active. This was due to the probability of new connections not landing on a specific node for the TTL duration. This occurred occasionally causing the counter to reset. Increasing the TTL value to 15m should reduce the probability of this significantly.

