### PR TITLE
Fix BPF verifier issue

### DIFF
--- a/connectivity-exporter/packet/c/cap.c
+++ b/connectivity-exporter/packet/c/cap.c
@@ -218,10 +218,10 @@ static inline int parse_sni(struct __sk_buff *skb, int data_offset, char *out)
 
   // Read the server name field.
   int counter = 0;
-  for (int i = 0; i < server_name_len; i++) {
+  for (int i = 0; i < TLS_MAX_SERVER_NAME_LEN; i++) {
     if (!out)
       break;
-    if (i >= TLS_MAX_SERVER_NAME_LEN)
+    if (i >= server_name_len)
       break;
     char b;
     bpf_skb_load_bytes(skb, server_name_off + i, &b, 1);


### PR DESCRIPTION
**What this PR does / why we need it**:

On Kernel 5.15, the current version fails after 354 iterations of the
unrolled for loop. TLS_MAX_SERVER_NAME_LEN is less than that (128) and
if the for loop is rewritten in this (equivalent) way, the BPF verifier
accepts the program (both on 5.13 and on 5.15).