### PR TITLE
Simplify metric expiration

### DIFF
--- a/connectivity-exporter/metrics/metrics_test.go
+++ b/connectivity-exporter/metrics/metrics_test.go
@@ -2,9 +2,7 @@ package metrics
 
 import (
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -19,12 +17,10 @@ func TestSNI(t *testing.T) {
 		SuccessfulConnections:       2,
 		RejectedConnections:         5,
 		RejectedConnectionsByClient: 1,
-		SNI:                         NewSNI(sni),
+		SNI:                         sni,
 	}
-	inc.SNI.StartTTL(&RealTimer{
-		Timer: time.NewTimer(TTL),
-	})
-	applyInc(inc)
+
+	inc.apply()
 
 	const secondsMetadata = `
 		# HELP connectivity_exporter_seconds_total Total number of seconds.
@@ -54,89 +50,6 @@ func TestSNI(t *testing.T) {
 
 	if err := testutil.CollectAndCompare(connections, strings.NewReader(connectionsMetadata+connectionsExpected)); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
-	}
-}
-
-type mockTimer struct {
-	c     chan time.Time
-	reset bool
-	wg    *sync.WaitGroup
-}
-
-func (t *mockTimer) resetTimer() {
-	t.reset = true
-}
-
-func (t *mockTimer) getChannel() <-chan time.Time {
-	return t.c
-}
-
-func (t *mockTimer) cleanup() {
-	t.wg.Done()
-}
-
-func TestTTL(t *testing.T) {
-	defer resetMetrics()
-	sni := "testsni"
-	inc := &Inc{
-		ActiveSeconds:               1,
-		FailedSeconds:               1,
-		ActiveFailedSeconds:         1,
-		SuccessfulConnections:       2,
-		RejectedConnections:         5,
-		RejectedConnectionsByClient: 1,
-		SNI:                         NewSNI(sni),
-	}
-
-	ch := make(chan time.Time)
-	wg := &sync.WaitGroup{}
-
-	inc.SNI.StartTTL(&mockTimer{
-		c:  ch,
-		wg: wg,
-	})
-
-	wg.Add(1)
-
-	// Apply the increment and verify that the metrics got created
-	applyInc(inc)
-	if testutil.CollectAndCount(seconds) != 3 {
-		t.Errorf("Expected 2 metrics got: %d", testutil.CollectAndCount(seconds))
-	}
-
-	// expire metrics
-	ch <- time.Now()
-	wg.Wait()
-
-	// verify metrics are gone
-	if testutil.CollectAndCount(seconds) != 0 {
-		t.Errorf("Expected 0 metrics got: %d", testutil.CollectAndCount(seconds))
-	}
-
-	// SNI appears again after it has been expired
-	inc = &Inc{
-		ActiveSeconds:               1,
-		FailedSeconds:               1,
-		ActiveFailedSeconds:         1,
-		SuccessfulConnections:       2,
-		RejectedConnections:         5,
-		RejectedConnectionsByClient: 1,
-		SNI:                         NewSNI(sni),
-	}
-	inc.SNI.StartTTL(&mockTimer{
-		c:  ch,
-		wg: wg,
-	})
-
-	applyInc(inc)
-	if testutil.CollectAndCount(seconds) != 3 {
-		t.Errorf("Expected 3 metrics got: %d", testutil.CollectAndCount(seconds))
-	}
-
-	// RefreshTTL should not affect the metrics
-	inc.SNI.refreshTTL <- nil
-	if testutil.CollectAndCount(seconds) != 3 {
-		t.Errorf("Expected 3 metrics got: %d", testutil.CollectAndCount(seconds))
 	}
 }
 

--- a/connectivity-exporter/metrics/types.go
+++ b/connectivity-exporter/metrics/types.go
@@ -5,7 +5,6 @@
 package metrics
 
 import (
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,23 +21,15 @@ type Inc struct {
 	SuccessfulConnections,
 	RejectedConnections,
 	RejectedConnectionsByClient float64
-	SNI *SNI
-}
-
-type SNI struct {
-	refreshTTL chan interface{}
-	name       string
-	Expired    bool
+	SNI string
 }
 
 const (
-	TTL       time.Duration = time.Minute * 15
-	namespace               = "connectivity_exporter"
+	Expiration = time.Minute * 15
+	namespace  = "connectivity_exporter"
 )
 
 var (
-	SNIMutex = sync.Mutex{}
-
 	seconds = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,


### PR DESCRIPTION
**What this PR does / why we need it**:

SNIs should be "expired" after 15 minutes of inactivity. Previously each SNI received its own goroutine that would start a timer. This timer would be reset whenever there was activity. However, this added unnecessary complexity and made it more difficult to test the code. With this PR the SNIs are now expired in a single goroutine where we check the last time that it was updated. This should simplify the code and make it more readable/ testable.

